### PR TITLE
Fix module matching

### DIFF
--- a/checker.ps1
+++ b/checker.ps1
@@ -145,7 +145,7 @@ try {
     $change = $changesDetected[0]
     #>
     $currentContent = $currentContent | ForEach-Object {
-      if ($_ -match "https\:\/\/www\.powershellgallery\.com\/packages\/$($change.Module)") {
+      if ($_ -match "https\:\/\/www\.powershellgallery\.com\/packages\/$($change.Module)[\/)]") {
         if ($_ -match '\| *((?:\d+\.){2,}\d+(?:-preview)?)\d* *\|') {
           $version = $Matches[1]
           "$($_ -replace ($version, $change.Version))"


### PR DESCRIPTION
By improving regex matching, the issue with matching (reported in #89) should be gone.

Proof here: https://github.com/robdy/msshells/pull/1