### PR TITLE
Simplify the script

### DIFF
--- a/checker.ps1
+++ b/checker.ps1
@@ -41,8 +41,6 @@ $modulesToBeChecked = @(
   'Microsoft.PowerApps.PowerShell',
   'MSCommerce'
 )
-$batchSize = 40
-$findPackagesEndpointUrl = 'https://www.powershellgallery.com/api/v2/FindPackagesById()'
 
 # Regexes
 $moduleRegex = '^\|(?:[^\|]*)\| *\[(?:[\w .]*)\]\(https\:\/\/www\.powershellgallery\.com\/packages\/(\w.*)\/?\) *\|([^\|]*)\|[^\|]*\|([^\|]*)\|[^\|]*'

--- a/checker.ps1
+++ b/checker.ps1
@@ -94,6 +94,10 @@ try {
     $moduleName = $modulesToBeChecked[0]
     #>
     $allModuleVersions = $null
+    $latestVersion = $null
+    $latestPreview = $null
+    $latestVersionNumber = $null
+    $latestPreviewNumber = $null
 
     $moduleEntry = $moduleData | Where-Object Modulename -eq $moduleName
     $allModuleVersions = Find-Module $moduleName -AllVersions -AllowPrerelease

--- a/checker.ps1
+++ b/checker.ps1
@@ -94,6 +94,8 @@ try {
     $moduleName = $modulesToBeChecked[0]
     #>
     $allModuleVersions = $null
+
+    $moduleEntry = $moduleData | Where-Object Modulename -eq $moduleName
     $allModuleVersions = Find-Module $moduleName -AllVersions -AllowPrerelease
     $latestVersion = $allModuleVersions | Where-Object {$_.AdditionalMetadata.IsAbsoluteLatestVersion -eq 'true'}
     $latestPreview = $allModuleVersions | Where-Object {$_.AdditionalMetadata.isPrerelease -eq 'true'} |

--- a/checker.ps1
+++ b/checker.ps1
@@ -100,26 +100,26 @@ try {
           Sort-Object {[System.Version]($_.Version -replace("-preview|-beta|-alpha",""))} |
           Select-Object -Last 1
   
-    if ($moduleEntry.Version -ne $latestVersion.properties.Version) {
+    if ($moduleEntry.Version -ne $latestVersion.Version) {
       $changesDetected += @{
         "Module" = $moduleName
         "Type" = "Release"
-        "Version" = $latestVersion.properties.Version
+        "Version" = $latestVersion.Version
       }
-      Write-Host "New version of $moduleName released: $($latestVersion.properties.Version)"
+      Write-Host "New version of $moduleName released: $($latestVersion.Version)"
     } else {
       Write-Verbose "No new version of $moduleName found"
     }
     if (
         $moduleEntryPrereleaseVersion -match '(\d+\.){2,3}\d+' -and
-        $moduleEntry.PrereleaseVersion -ne $latestPreview.properties.Version
+        $moduleEntry.PrereleaseVersion -ne $latestPreview.Version
       ) {
         $changesDetected += @{
           "Module" = $moduleName
           "Type" = "Prerelease"
-          "Version" = $latestPreview.properties.Version
+          "Version" = $latestPreview.Version
         }
-      Write-Host "New prerelease version of $moduleName found: $($latestPreview.properties.Version)"
+      Write-Host "New prerelease version of $moduleName found: $($latestPreview.Version)"
     } else {
       Write-Verbose "No new prerelease version of $moduleName found"
     }

--- a/checker.ps1
+++ b/checker.ps1
@@ -113,7 +113,7 @@ try {
       Write-Verbose "No new version of $moduleName found"
     }
     if (
-        $moduleEntryPrereleaseVersion -match '(\d+\.){2,3}\d+' -and
+        $moduleEntry.PrereleaseVersion -match '(\d+\.){2,3}\d+' -and
         $moduleEntry.PrereleaseVersion -ne $latestPreviewNumber
       ) {
         $changesDetected += @{

--- a/checker.ps1
+++ b/checker.ps1
@@ -95,31 +95,33 @@ try {
     #>
     $allModuleVersions = $null
     $allModuleVersions = Find-Module $moduleName -AllVersions -AllowPrerelease
-    $latestVersion = $allModuleVersions | Where-Object {$_.AdditionalMetadata.IsLatestVersion -eq 'true'}
+    $latestVersion = $allModuleVersions | Where-Object {$_.AdditionalMetadata.IsAbsoluteLatestVersion -eq 'true'}
     $latestPreview = $allModuleVersions | Where-Object {$_.AdditionalMetadata.isPrerelease -eq 'true'} |
           Sort-Object {[System.Version]($_.Version -replace("-preview|-beta|-alpha",""))} |
           Select-Object -Last 1
+    $latestVersionNumber = $latestVersion.Version
+    $latestPreviewNumber = $latestPreview.Version
   
-    if ($moduleEntry.Version -ne $latestVersion.Version) {
+    if ($moduleEntry.Version -ne $latestVersionNumber) {
       $changesDetected += @{
         "Module" = $moduleName
         "Type" = "Release"
-        "Version" = $latestVersion.Version
+        "Version" = $latestVersionNumber
       }
-      Write-Host "New version of $moduleName released: $($latestVersion.Version)"
+      Write-Host "New version of $moduleName released: $latestVersionNumber"
     } else {
       Write-Verbose "No new version of $moduleName found"
     }
     if (
         $moduleEntryPrereleaseVersion -match '(\d+\.){2,3}\d+' -and
-        $moduleEntry.PrereleaseVersion -ne $latestPreview.Version
+        $moduleEntry.PrereleaseVersion -ne $latestPreviewNumber
       ) {
         $changesDetected += @{
           "Module" = $moduleName
           "Type" = "Prerelease"
-          "Version" = $latestPreview.Version
+          "Version" = $latestPreviewNumber
         }
-      Write-Host "New prerelease version of $moduleName found: $($latestPreview.Version)"
+      Write-Host "New prerelease version of $moduleName found: $latestPreviewNumber"
     } else {
       Write-Verbose "No new prerelease version of $moduleName found"
     }


### PR DESCRIPTION
As suggested in #97 using `Find-Module` is more readable than using web requests.

I also noticed the bug causing the prerelease versions to be ignored. It's now fixed!